### PR TITLE
PR for compresscmd, uncompresscmd and compressext options

### DIFF
--- a/library/logrotate.py
+++ b/library/logrotate.py
@@ -68,6 +68,21 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: true
+  compresscmd:
+    description:
+      - command to use to compress log files
+    required: false
+    default: False
+  uncompresscmd:
+    description:
+      - command to use to uncompress log files
+    required: false
+    default: False
+  compressext
+    description:
+      - extension to use on compressed logfiles, if compression is enabled
+    required: false
+    default: False
   delaycompress:
     description:
       - delay compress
@@ -178,6 +193,12 @@ def generate_config(module):
     options = []
     if module.params.get('compress'):
         options += [ 'compress' ]
+    if module.params.get('compresscmd'):
+        options += [ 'compresscmd %s' % module.params.get('compresscmd') ]
+    if module.params.get('uncompresscmd'):
+        options += [ 'uncompresscmd %s' % module.params.get('uncompresscmd') ]
+    if module.params.get('compressext'):
+        options += [ 'compressext %s' % module.params.get('compressext') ]
     if module.params.get('delaycompress'):
         options += [ 'delaycompress' ]
     if module.params.get('missingok'):
@@ -256,6 +277,9 @@ def main():
         frequency       = dict(required=False, default='daily', choices=['daily', 'weekly', 'monthly', 'yearly']),
         rotate          = dict(required=False, default=30, type='int'),
         compress        = dict(required=False, default='yes', type='bool'),
+        compresscmd     = dict(required=False),
+        uncompresscmd   = dict(required=False),
+        compressext     = dict(required=False),
         copytruncate    = dict(required=False, default='no', type='bool'),
         delaycompress   = dict(required=False, default='yes', type='bool'),
         missingok       = dict(required=False, default='yes', type='bool'),

--- a/templates/logrotate.conf.j2
+++ b/templates/logrotate.conf.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 create
 compress
 delaycompress


### PR DESCRIPTION
Added thoses three options to your role :)

It allow specifying compression settings to use xz for example : 
```
/var/log/apache2/*.log
{
  compress
  compresscmd /usr/bin/xz
  uncompresscmd /usr/bin/unxz
  compressext .xz
  delaycompress
...
```

Also added ansible_managed in logrotate.conf template